### PR TITLE
支持select远程可搜索初始值回写

### DIFF
--- a/docs/website-data-api/selectExtraOptionsApi.json
+++ b/docs/website-data-api/selectExtraOptionsApi.json
@@ -1,0 +1,13 @@
+{
+    "status": 0,
+    "data": [
+        {
+            "label": "张三",
+            "value": "zhangsan"
+        },
+        {
+            "label": "李四",
+            "value": "lisi"
+        }
+    ]
+}

--- a/src/fields/fieldSelect.vue
+++ b/src/fields/fieldSelect.vue
@@ -93,6 +93,7 @@ export default {
         return {
             loading: false,
             options: [],
+            extraOptions: []
         };
     },
     computed: {
@@ -106,7 +107,11 @@ export default {
             return !this.field.multiple ? this.field.clearable : false;
         },
         computedOptions() {
-            const options = this.options.length > 0 ? this.options : (Array.isArray(this.field.options) ? this.field.options : []);
+            let options = this.options.length > 0 ? this.options : (Array.isArray(this.field.options) ? this.field.options : []);
+            if (this.extraOptions) {
+                options = this.extraOptions.concat(options);
+            }
+
             const uniqeOptions = [];
             const uniqeOptionsMap = {};
             for (let i = 0; i < options.length; i++) {
@@ -121,11 +126,29 @@ export default {
         optionsApi() {
             return this.field.api || !Array.isArray(this.field.options) ? this.field.options : '';
         },
+        extraOptionsApi() {
+            return !Array.isArray(this.field.extraOptions) ? this.field.extraOptions : '';
+        },
         value() {
             return getValue({
                 originModel: this.form.model,
                 model: this.field.model
             }) || '';
+        }
+    },
+    created() {
+        // local
+        if(Array.isArray(this.field.extraOptions)) {
+            this.extraOptions = this.field.extraOptions;
+        }
+        // remote
+        if (this.extraOptionsApi) {
+            const params = {
+                values: this.value
+            };
+            this.requestMethod('get', this.extraOptionsApi, params).then(res => {
+                this.extraOptions = res.data;
+            });
         }
     },
     methods: {

--- a/website/code/doc/select.js
+++ b/website/code/doc/select.js
@@ -148,12 +148,23 @@ const filterableAndMultipleField = {
     model: 'cities',
     filterable: true,
     multiple: true,
-    options: '/selectApi'
+    options: '/selectApi',
+    extraOptions: '/selectExtraOptionsApi'
+    // extraOptions: [
+    //     {
+    //         label: '张三',
+    //         value: 'zhangsan'
+    //     },
+    //     {
+    //         label: '李四',
+    //         value: 'lisi'
+    //     }
+    // ]
 };
 
 const filterableModel = {
     city: 'Beijing',
-    cities: ['Beijing', 'Shanghai']
+    cities: ['zhangsan', 'lisi']
 };
 
 filterable.data = {


### PR DESCRIPTION
通过添加如下配置，实现select{remote, search}情况下，初始值不展示label的问题。
```
extraOptions: '/selectExtraOptionsApi'
    // extraOptions: [
    //     {
    //         label: '张三',
    //         value: 'zhangsan'
    //     },
    //     {
    //         label: '李四',
    //         value: 'lisi'
    //     }
    // ]
```